### PR TITLE
First working version with rollup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4778,6 +4778,66 @@
         "rollup": "^2.42.0"
       }
     },
+    "node_modules/@rollup/plugin-typescript": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.0.0.tgz",
+      "integrity": "sha512-goPyCWBiimk1iJgSTgsehFD5OOFHiAknrRJjqFCudcW8JtWiBlK284Xnn4flqMqg6YAjVG/EE+3aVzrL5qNSzQ==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.14.0||^3.0.0",
+        "tslib": "*",
+        "typescript": ">=3.7.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
+        "tslib": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-typescript/node_modules/@rollup/pluginutils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+      "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-typescript/node_modules/@types/estree": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+      "dev": true
+    },
+    "node_modules/@rollup/plugin-typescript/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
@@ -29696,17 +29756,21 @@
       }
     },
     "packages/biowc-scatter": {
-      "version": "0.0.0",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "d3": "^6.2.0",
+        "download-button": "^0.0.0",
         "lit": "^2.0.2"
       },
       "devDependencies": {
         "@custom-elements-manifest/analyzer": "^0.4.17",
         "@open-wc/eslint-config": "^9.2.0",
         "@open-wc/testing": "^3.1.7",
+        "@rollup/plugin-node-resolve": "^15.0.1",
+        "@rollup/plugin-typescript": "^11.0.0",
         "@types/d3": "^7.4.0",
+        "@types/estree": "^0.0.47",
         "@typescript-eslint/eslint-plugin": "^5.48.1",
         "@typescript-eslint/parser": "^5.48.1",
         "@web/dev-server": "^0.1.35",
@@ -29721,6 +29785,77 @@
         "tslib": "^2.4.1",
         "typescript": "^4.9.4"
       }
+    },
+    "packages/biowc-scatter/node_modules/@rollup/plugin-node-resolve": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.0.1.tgz",
+      "integrity": "sha512-ReY88T7JhJjeRVbfCyNj+NXAG3IIsVMsX9b5/9jC98dRP8/yxlZdz7mHZbHk5zHr24wZZICS5AcXsFZAXYUQEg==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-builtin-module": "^3.2.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "packages/biowc-scatter/node_modules/@rollup/pluginutils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+      "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "packages/biowc-scatter/node_modules/@rollup/pluginutils/node_modules/@types/estree": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+      "dev": true
+    },
+    "packages/biowc-scatter/node_modules/@types/estree": {
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.47.tgz",
+      "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==",
+      "dev": true
+    },
+    "packages/biowc-scatter/node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true
+    },
+    "packages/biowc-scatter/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
     },
     "packages/download-button": {
       "version": "0.0.0",
@@ -33412,6 +33547,41 @@
         "is-builtin-module": "^3.1.0",
         "is-module": "^1.0.0",
         "resolve": "^1.19.0"
+      }
+    },
+    "@rollup/plugin-typescript": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.0.0.tgz",
+      "integrity": "sha512-goPyCWBiimk1iJgSTgsehFD5OOFHiAknrRJjqFCudcW8JtWiBlK284Xnn4flqMqg6YAjVG/EE+3aVzrL5qNSzQ==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^5.0.1",
+        "resolve": "^1.22.1"
+      },
+      "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+          "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "^1.0.0",
+            "estree-walker": "^2.0.2",
+            "picomatch": "^2.3.1"
+          }
+        },
+        "@types/estree": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+          "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+          "dev": true
+        },
+        "estree-walker": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+          "dev": true
+        }
       }
     },
     "@rollup/pluginutils": {
@@ -37728,7 +37898,10 @@
         "@custom-elements-manifest/analyzer": "^0.4.17",
         "@open-wc/eslint-config": "^9.2.0",
         "@open-wc/testing": "^3.1.7",
+        "@rollup/plugin-node-resolve": "^15.0.1",
+        "@rollup/plugin-typescript": "^11.0.0",
         "@types/d3": "^7.4.0",
+        "@types/estree": "^0.0.47",
         "@typescript-eslint/eslint-plugin": "^5.48.1",
         "@typescript-eslint/parser": "^5.48.1",
         "@web/dev-server": "^0.1.35",
@@ -37737,6 +37910,7 @@
         "@web/test-runner-playwright": "^0.8.10",
         "concurrently": "^5.3.0",
         "d3": "^6.2.0",
+        "download-button": "^0.0.0",
         "eslint": "^8.31.0",
         "eslint-config-prettier": "^8.6.0",
         "lint-staged": "^10.5.4",
@@ -37744,6 +37918,59 @@
         "prettier": "^2.8.2",
         "tslib": "^2.4.1",
         "typescript": "^4.9.4"
+      },
+      "dependencies": {
+        "@rollup/plugin-node-resolve": {
+          "version": "15.0.1",
+          "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.0.1.tgz",
+          "integrity": "sha512-ReY88T7JhJjeRVbfCyNj+NXAG3IIsVMsX9b5/9jC98dRP8/yxlZdz7mHZbHk5zHr24wZZICS5AcXsFZAXYUQEg==",
+          "dev": true,
+          "requires": {
+            "@rollup/pluginutils": "^5.0.1",
+            "@types/resolve": "1.20.2",
+            "deepmerge": "^4.2.2",
+            "is-builtin-module": "^3.2.0",
+            "is-module": "^1.0.0",
+            "resolve": "^1.22.1"
+          }
+        },
+        "@rollup/pluginutils": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+          "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "^1.0.0",
+            "estree-walker": "^2.0.2",
+            "picomatch": "^2.3.1"
+          },
+          "dependencies": {
+            "@types/estree": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+              "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+              "dev": true
+            }
+          }
+        },
+        "@types/estree": {
+          "version": "0.0.47",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.47.tgz",
+          "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==",
+          "dev": true
+        },
+        "@types/resolve": {
+          "version": "1.20.2",
+          "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+          "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+          "dev": true
+        },
+        "estree-walker": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+          "dev": true
+        }
       }
     },
     "bl": {

--- a/packages/biowc-scatter/.gitignore
+++ b/packages/biowc-scatter/.gitignore
@@ -22,3 +22,5 @@
 
 storybook-static
 custom-elements.json
+
+.rollup.cache

--- a/packages/biowc-scatter/demo/standalone.html
+++ b/packages/biowc-scatter/demo/standalone.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body {
+        background: #fafafa;
+      }
+    </style>
+  </head>
+  <body>
+    <biowc-scatter id="scatterplot">
+      if you see this, the web component is not working :(
+    </biowc-scatter>
+
+    <script type="module">
+      const biowcScatter = document.querySelector('#scatterplot');
+
+      biowcScatter.idKey = 'Sample name';
+      biowcScatter.valueKey = 'abundance';
+      biowcScatter.xLabel = 'abundance Gene_X';
+      biowcScatter.xValues = [
+        { 'Sample name': 'sample1', abundance: 1 },
+        { 'Sample name': 'sample2', abundance: 3 },
+        { 'Sample name': 'sample4', abundance: 3 },
+        { 'Sample name': 'sample5', abundance: 2 },
+      ];
+      biowcScatter.yLabel = 'abundance Gene_Y';
+      biowcScatter.yValues = [
+        { 'Sample name': 'sample1', abundance: 1 },
+        { 'Sample name': 'sample2', abundance: 2 },
+        { 'Sample name': 'sample4', abundance: 3 },
+        { 'Sample name': 'sample5', abundance: -2.5 },
+      ];
+    </script>
+    <script type="module" src="../dist/bundle.js"></script>
+  </body>
+</html>

--- a/packages/biowc-scatter/demo/vanillajs+unpkg.html
+++ b/packages/biowc-scatter/demo/vanillajs+unpkg.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body {
+        background: #fafafa;
+      }
+    </style>
+  </head>
+  <body>
+    <biowc-scatter id="scatterplot">
+      if you see this, the web component is not working :(
+    </biowc-scatter>
+
+    <script type="module">
+      const biowcScatter = document.querySelector('#scatterplot');
+
+      biowcScatter.idKey = 'Sample name';
+      biowcScatter.valueKey = 'abundance';
+      biowcScatter.xLabel = 'abundance Gene_X';
+      biowcScatter.xValues = [
+        { 'Sample name': 'sample1', abundance: 1 },
+        { 'Sample name': 'sample2', abundance: 3 },
+        { 'Sample name': 'sample4', abundance: 3 },
+        { 'Sample name': 'sample5', abundance: 2 },
+      ];
+      biowcScatter.yLabel = 'abundance Gene_Y';
+      biowcScatter.yValues = [
+        { 'Sample name': 'sample1', abundance: 1 },
+        { 'Sample name': 'sample2', abundance: 2 },
+        { 'Sample name': 'sample4', abundance: 3 },
+        { 'Sample name': 'sample5', abundance: -2.5 },
+      ];
+    </script>
+
+    <biowc-scatter id="scatterplot2">
+      if you see this, the web component is not working :(
+    </biowc-scatter>
+
+    <script type="module">
+      const biowcScatter = document.querySelector('#scatterplot2');
+
+      biowcScatter.idKey = 'Sample name';
+      biowcScatter.valueKey = 'abundance';
+      biowcScatter.xLabel = 'abundance Gene_X';
+      biowcScatter.xValues = [
+        { 'Sample name': 'sample1', abundance: 4 },
+        { 'Sample name': 'sample2', abundance: 3 },
+        { 'Sample name': 'sample4', abundance: 3 },
+        { 'Sample name': 'sample5', abundance: 1 },
+      ];
+      biowcScatter.yLabel = 'abundance Gene_Y';
+      biowcScatter.yValues = [
+        { 'Sample name': 'sample1', abundance: 1 },
+        { 'Sample name': 'sample2', abundance: 2.5 },
+        { 'Sample name': 'sample4', abundance: 3 },
+        { 'Sample name': 'sample5', abundance: -2.5 },
+      ];
+    </script>
+
+    <script type="module" src="https://unpkg.com/biowc-scatter"></script>
+  </body>
+</html>

--- a/packages/biowc-scatter/package-lock.json
+++ b/packages/biowc-scatter/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "biowc-scatter",
-  "version": "0.0.0",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/biowc-scatter/package.json
+++ b/packages/biowc-scatter/package.json
@@ -3,7 +3,7 @@
   "description": "Webcomponent biowc-scatter following open-wc recommendations",
   "license": "MIT",
   "author": "biowc-scatter",
-  "version": "0.0.0",
+  "version": "0.1.4",
   "main": "dist/src/index.js",
   "module": "dist/src/index.js",
   "exports": {
@@ -14,6 +14,7 @@
     "analyze": "cem analyze --litelement",
     "start": "tsc && concurrently -k -r \"tsc --watch --preserveWatchOutput\" \"wds\"",
     "build": "tsc && npm run analyze -- --exclude dist",
+    "bundle": "rollup -c",
     "prepublish": "tsc && npm run analyze -- --exclude dist",
     "lint": "eslint --ext .ts,.html . --ignore-path .gitignore && prettier \"**/*.ts\" --check --ignore-path .gitignore",
     "format": "eslint --ext .ts,.html . --fix --ignore-path .gitignore && prettier \"**/*.ts\" --write --ignore-path .gitignore",
@@ -23,13 +24,17 @@
   },
   "dependencies": {
     "d3": "^6.2.0",
+    "download-button": "^0.0.0",
     "lit": "^2.0.2"
   },
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "^0.4.17",
     "@open-wc/eslint-config": "^9.2.0",
     "@open-wc/testing": "^3.1.7",
+    "@rollup/plugin-node-resolve": "^15.0.1",
+    "@rollup/plugin-typescript": "^11.0.0",
     "@types/d3": "^7.4.0",
+    "@types/estree": "^0.0.47",
     "@typescript-eslint/eslint-plugin": "^5.48.1",
     "@typescript-eslint/parser": "^5.48.1",
     "@web/dev-server": "^0.1.35",
@@ -78,5 +83,9 @@
       "eslint --fix",
       "prettier --write"
     ]
-  }
+  },
+  "files": [
+    "dist/bundle.js"
+  ],
+  "unpkg": "dist/bundle.js"
 }

--- a/packages/biowc-scatter/rollup.config.js
+++ b/packages/biowc-scatter/rollup.config.js
@@ -1,0 +1,13 @@
+import typescript from '@rollup/plugin-typescript';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+
+
+export default {
+  input: 'src/biowc-scatter.ts',
+  output: {
+    file: 'dist/bundle.js',
+    format: 'umd'
+  },
+  external: 'all',
+  plugins: [typescript(), nodeResolve()]
+};

--- a/packages/biowc-scatter/src/BiowcScatter.ts
+++ b/packages/biowc-scatter/src/BiowcScatter.ts
@@ -3,7 +3,7 @@ import { property } from 'lit/decorators.js';
 import * as d3v6 from 'd3';
 import { HTMLTemplateResult, PropertyValues } from 'lit/development';
 import styles from './biowc-scatter.css';
-import '../../../download-button/dist/src/download-button.js';
+import 'download-button/download-button.js';
 
 export class BiowcScatter extends LitElement {
   static styles = styles;


### PR DESCRIPTION
Adds functionality to import the component as a standalone package in vanilla javascript as:
```html
<script type="module" src="https://unpkg.com/biowc-scatter"></script>
```

See the wiki for documentation: https://github.com/wilhelm-lab/biowc-core/wiki/Bundling